### PR TITLE
NEO-300: Responsive design

### DIFF
--- a/neonion/static/stylesheets/partials/_annotationgrid.scss
+++ b/neonion/static/stylesheets/partials/_annotationgrid.scss
@@ -15,8 +15,8 @@
       margin-left: $column-gap;
       margin-bottom: $baseline;
 
-      width: 3*$column + 2*$column-gap + 2;
-      height: 7*$baseline + 2;
+      width: 3*$column + 2*$column-gap;
+      height: 7*$baseline;
 
       font-size: $base-font-size;
       line-height: $baseline;

--- a/neonion/static/stylesheets/partials/_base.scss
+++ b/neonion/static/stylesheets/partials/_base.scss
@@ -8,6 +8,8 @@ padding and border, but not the margin
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  padding: 0;
+  margin: 0;
 }
 
 body {
@@ -18,6 +20,11 @@ body {
 
 p {
   margin: $half-baseline 0 ;
+}
+
+h2 {
+  padding-top: 0.5em;
+  padding-bottom: 1.1em;
 }
 
 // left Sidebar containing navigation and logo

--- a/neonion/static/stylesheets/partials/_navigation.scss
+++ b/neonion/static/stylesheets/partials/_navigation.scss
@@ -37,7 +37,8 @@
 
   li {
     display: inline-block;
-    padding: 0px $baseline 0px 0px;
+    height: $baseline;
+    padding: 0em $baseline 3.7em 0em;
 
     a {
       font-weight: bold;

--- a/neonion/templates/base_my_annotations.html
+++ b/neonion/templates/base_my_annotations.html
@@ -12,34 +12,45 @@
         {% url 'neonion.views.annotations_occurrences' as url_annotations_occurrences %}
         {% url 'neonion.views.ann_documents' as url_ann_documents %}
 
+
         <h3>My Annotations</h3>
     </div>
 
+    <nav class="nav-horizontal">
+        <ul>
+            <li ng-class="{active:tab===1}"><a href="" ng-click="tab = 1">Overview</a></li>
+            <li ng-class="{active:tab===2}"><a href="" ng-click="tab = 2">Occurrences</a></li>
+            <li ng-class="{active:tab===3}"><a href="" ng-click="tab = 3">All Documents</a></li>
+        </ul>
+    </nav>
     <ul id="annotation-table" class="annotation-grid" ng-controller="AnnotationStoreCtrl" ng-cloak>
 
         {% verbatim %}
-        <li ng-repeat="occurrence in occurrences | filter:filterAnnotations | orderBy:'-created'">
-            <div>
-                <div class="ann-header">
-                    {{ occurrence.ann }}
-                </div>
-                <div class="sub-info">
-                    is {{ occurrence.typeof }}
-                </div>
-                <div></div>
+            <li ng-repeat="occurrence in occurrences | filter:filterAnnotations | orderBy:'-created'">
                 <div>
-                    <a href="/annotations_occurrences/{{ occurrence.ann | escape }}">{{ occurrence.count }} Occurrences</a>
+                    <div class="ann-header">
+                        {{ occurrence.ann }}
+                    </div>
+                    <div class="sub-info">
+                        is {{ occurrence.typeof }}
+                    </div>
+                    <div></div>
+                    <div>
+                        <a href="/annotations_occurrences/{{ occurrence.ann | escape }}">{{ occurrence.count }}
+                            Occurrences</a>
+                    </div>
+                    <div>
+                        <a href="/ann_documents/{{ occurrence.ann | escape }}">in {{ occurrence.docs.length }}
+                            Documents</a>
+                    </div>
+                    <div></div>
+                    <div class="sub-info">
+                        {{ occurrence.last | date : "MM/dd/yyyy 'at' h:mma" }}
+                    </div>
                 </div>
-                <div>
-                    <a href="/ann_documents/{{ occurrence.ann | escape }}">in {{ occurrence.docs.length }} Documents</a>
-                </div>
-                <div></div>
-                <div class="sub-info">
-                    {{ occurrence.last | date : "MM/dd/yyyy 'at' h:mma" }}
-                </div>
-            </div>
-        </li>
+            </li>
         {% endverbatim %}
 
     </ul>
+    </div>
 {% endblock %}

--- a/neonion/templates/base_settings.html
+++ b/neonion/templates/base_settings.html
@@ -13,8 +13,8 @@
             <ul>
                 <li ng-class="{active:tab===1}"><a href="" ng-click="tab = 1">Annotation Sets</a></li>
                 <li ng-class="{active:tab===2}"><a href="" ng-click="tab = 2">Properties</a></li>
-                <li ng-class="{active:tab===3}"><a href="" ng-click="tab = 3" >NER Settings</a></li>
-            </ul></br>
+                <li ng-class="{active:tab===3}"><a href="" ng-click="tab = 3">NER Settings</a></li>
+            </ul>
         </nav>
 
         <div class="wrapper" ng-switch="tab">


### PR DESCRIPTION
Habe die Pixel größtenteils auf em und % umgestellt, nur bei der Seitenbreite gab es noch Probleme, die ich nicht lösen konnte. Um Fluid Grids zu erstellen, habe ich diese Formel gefunden: target ÷ context = result (Referenz: http://alistapart.com/article/fluidgrids). 

$column-gap: 1.2345679012345679%;     //16px;
$column: 2.9320987654320988%;         //38px;

Diese Änderung zerstört aber die Annotationsübersicht, da muss ich mich am Wochenende nochmal dransetzen, um eine Lösung zu finden. 
