### PR TITLE
NEO-467: Show Freetext annotation as new tab in annotation overview

### DIFF
--- a/neonion/static/js/angular/filters.js
+++ b/neonion/static/js/angular/filters.js
@@ -1,4 +1,15 @@
 neonionApp
     .filter('escape', function() {
     return window.encodeURIComponent;
+})
+.filter('truncate', function () {
+    return function (text, position) {
+        if (position == 'left')
+            text = '[...]\u00A0' + text;
+
+        if (position == 'right')
+            text = text + '\u00A0[...]';
+
+        return text;
+    };
 });

--- a/neonion/static/partials/myannotation-annotation-list.html
+++ b/neonion/static/partials/myannotation-annotation-list.html
@@ -1,23 +1,17 @@
-<ul id="annotation-table" class="annotation-grid" ng-controller="MyAnnotationListCtrl" ng-cloak>
-    <li ng-repeat="occurrence in occurrences | filter:filterAnnotations | orderBy:'-created'">
-        <div>
-            <div class="ann-header">
-                {{ occurrence.ann }}
-            </div>
-            <div class="sub-info">
-                is {{ occurrence.typeof }}
-            </div>
-            <div></div>
-            <div>
-                <a href="/annotations_occurrences/{{ occurrence.ann | escape }}">{{ occurrence.count }} Occurrences</a>
-            </div>
-            <div>
-                <a href="/ann_documents/{{ occurrence.ann | escape }}">in {{ occurrence.docs.length }} Documents</a>
-            </div>
-            <div></div>
-            <div class="sub-info">
-                {{ occurrence.last | date : "MM/dd/yyyy 'at' h:mma" }}
-            </div>
+<div ng-init="tab = 2" ng-cloak>
+    <nav class="nav-horizontal">
+        <ul>
+            <li ng-class="{active:tab===1}"><a href="" ng-click="tab = 1">Semantic Annotation</a></li>
+            <li ng-class="{active:tab===2}"><a href="" ng-click="tab = 2">Freetext Annotation</a></li>
+        </ul>
+    </nav>
+
+    <div class="wrapper" ng-switch="tab">
+        <div ng-switch-when="1">
+            <ng-include src="'/static/partials/myannotations/semantic-annotation.html'"></ng-include>
         </div>
-    </li>
-</ul>
+        <div ng-switch-when="2">
+            <ng-include src="'/static/partials/myannotations/freetext-annotation.html'"></ng-include>
+        </div>
+    </div>
+</div>

--- a/neonion/static/partials/myannotations/freetext-annotation.html
+++ b/neonion/static/partials/myannotations/freetext-annotation.html
@@ -1,0 +1,26 @@
+<ul class="list-reset" ng-controller="MyAnnotationListCtrl" ng-cloak>
+    <li ng-repeat="document in freetextAnnotations">
+        <h3 ng-if="documents[document.id]">
+            <a href="/annotator/{{document.id}}#?workspace={{ document.visibility }}" target="blank">{{ documents[document.id] }}</a>
+        </h3>
+        <h3 ng-if="!documents[document.id]">Document was deleted</h3>
+        <small ng-if="groups[document.visibility]"><i class="fa fa-circle-o"></i> {{ groups[document.visibility] }}</small>
+        <small ng-if="!groups[document.visibility]"><i class="fa fa-circle-o"></i> Private</small>
+        <table class="table-freetext-annotation">
+            <thead>
+                <tr>
+                  <th class="context">Context</th>
+                  <th class="annotation">Annotation</th>
+                  <th class="date">Creation Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="anno in document.annotations">
+                    <td class="context">{{ anno.contextLeft | truncate:'left' }}&nbsp;<a class="mark" href="/annotator/{{document.id}}#?workspace={{ document.visibility }}" target="blank">{{ anno.context }}&nbsp;<i class="fa fa-external-link"></i></a>&nbsp;{{ anno.contextRight | truncate:'right' }}</td>
+                    <td class="annotation">{{ anno.annotation }}</td>
+                    <td class="date">{{ anno.date }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </li>
+</ul>

--- a/neonion/static/partials/myannotations/semantic-annotation.html
+++ b/neonion/static/partials/myannotations/semantic-annotation.html
@@ -1,0 +1,25 @@
+<ul id="annotation-table" class="annotation-grid" ng-controller="MyAnnotationListCtrl" ng-cloak>
+
+    <li ng-repeat="occurrence in occurrences | filter:filterAnnotations | orderBy:'-created'">
+        <div>
+            <div class="ann-header">
+                {{ occurrence.ann }}
+            </div>
+            <div class="sub-info">
+                is {{ occurrence.typeof }}
+            </div>
+            <div></div>
+            <div>
+                <a href="/annotations_occurrences/{{ occurrence.ann | escape }}">{{ occurrence.count }} Occurrences</a>
+            </div>
+            <div>
+                <a href="/ann_documents/{{ occurrence.ann | escape }}">in {{ occurrence.docs.length }} Documents</a>
+            </div>
+            <div></div>
+            <div class="sub-info">
+                {{ occurrence.last | date : "MM/dd/yyyy 'at' h:mma" }}
+            </div>
+        </div>
+    </li>
+
+</ul>

--- a/neonion/static/stylesheets/partials/_tables.scss
+++ b/neonion/static/stylesheets/partials/_tables.scss
@@ -16,6 +16,20 @@ th, tr {
   vertical-align: top;
 }
 
+.table-freetext-annotation {
+  table-layout: fixed;
+  word-wrap:break-word;
+
+  th, td {
+    &.context { width: 45%; }
+    &.annotation { width: 40%; }
+    &.date {
+      width: 15%;
+      text-align: right;
+    }
+  }
+}
+
 .checkbox {
   width: 2*$column;
   height: $baseline;

--- a/neonion/static/stylesheets/partials/_typography.scss
+++ b/neonion/static/stylesheets/partials/_typography.scss
@@ -26,3 +26,25 @@ hr {
   border: solid $silver;
   border-width: 1px 0 0;
 }
+
+.mark, mark {
+  background-color: transparentize($tangerine, 0.7);
+}
+
+a {
+  color: $ship-gray;
+  text-decoration: underline;
+
+  &:hover,
+  &:focus {
+    color: $black;
+  }
+
+  &.mark {
+    text-decoration: none;
+
+    &:hover {
+      background-color: $tangerine;
+    }
+  }
+}


### PR DESCRIPTION
- seperating tabs in semantic and freetext annotation (seperate template)
- list of tables
- one table shows all annotations of one doc with certain visibility (private, public, group)
- documents can have more that one table if they belong to more than one group (e.g private and public)
- show title of doc and visibiilty (private, public, group)
- title of doc is clickable (jump to doc) if document still exists
- also annotations are show even the doc doesnt exists anymore
- added angular filter for truncating with [...]
- added mark tag, styling with light orange (using a sass function for lightning)
- annotation is clickable and gets darker while hovering (jump to doc, not to annotation yet!)
- table is fixed and words are wrapped, so non-breaking words do not mess the layout

closes: NEO-469, NEO-470, NEO-472
