### PR TITLE
Extended SemanticAnnotationValidator to consider motivation 'oa:linking'

### DIFF
--- a/common/exceptions.py
+++ b/common/exceptions.py
@@ -1,12 +1,17 @@
 
 
-class NoConceptAnnotationError(Exception):
+class InvalidAnnotationError(Exception):
 
-    def __init__(self, value):
-        self.value = value
+    def __init__(self, message, code=None, params=None):
+        super(InvalidAnnotationError, self).__init__(message, code, params)
 
     def __str__(self):
-        return repr(self.value)
+        if hasattr(self, 'error_dict'):
+            return repr(dict(self))
+        return repr(list(self))
+
+    def __repr__(self):
+        return 'InvalidAnnotationError(%s)' % self
 
 
 class InvalidResourceTypeError(Exception):

--- a/common/statements.py
+++ b/common/statements.py
@@ -1,4 +1,4 @@
-from exceptions import NoConceptAnnotationError
+from exceptions import InvalidAnnotationError
 from common.vocab import OpenAnnotation, neonion
 
 DEFAULT_PREFIXES = '''PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>
@@ -79,7 +79,7 @@ class Annotation:
 
             return query
         else:
-            raise NoConceptAnnotationError(annotation)
+            raise InvalidAnnotationError(annotation)
 
     @staticmethod
     def delete_annotation_statement(annotation):
@@ -87,7 +87,7 @@ class Annotation:
         if 'oa' in annotation:
             return ''
         else:
-            raise NoConceptAnnotationError(annotation)
+            raise InvalidAnnotationError(annotation)
 
     @staticmethod
     def substatement_body_tag(annotation):
@@ -95,7 +95,7 @@ class Annotation:
         if 'oa' in annotation:
             return ''
         else:
-            raise NoConceptAnnotationError(annotation)
+            raise InvalidAnnotationError(annotation)
 
     @staticmethod
     def substatement_body_semantic_tag(annotation):
@@ -103,7 +103,7 @@ class Annotation:
         if 'oa' in annotation:
             return ''
         else:
-            raise NoConceptAnnotationError(annotation)
+            raise InvalidAnnotationError(annotation)
 
     @staticmethod
     def statement_about_resource(annotation):
@@ -126,7 +126,7 @@ class Annotation:
 
             return query
         else:
-            raise NoConceptAnnotationError(annotation)
+            raise InvalidAnnotationError(annotation)
 
 def metadata_statement(document):
     document_uri = "http://neonion.org/document/" + document.id

--- a/common/vocab.py
+++ b/common/vocab.py
@@ -29,3 +29,4 @@ class OpenAnnotation:
         tagging = 'oa:tagging'
         classifying = 'oa:classifying'
         identifying = 'oa:identifying'
+        linking = 'oa:linking'

--- a/neonion/tests.py
+++ b/neonion/tests.py
@@ -30,7 +30,7 @@ class ViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # my annotations
-        response = self.client.get(reverse(views.my_annotations))
+        response = self.client.get(reverse(views.annotations))
         self.assertEqual(response.status_code, 200)
 
         # accounts

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ dj-database-url==0.3.0
 dj-static==0.0.6
 djangorestframework==3.0.0
 elasticsearch==1.2.0
-enum==0.4.4
+enum34 1.0.4
 html5lib==1.0b3
 ipython==2.3.1
 iso8601==0.1.10


### PR DESCRIPTION
- rename exception NoSemanticAnnotationError to InvalidAnnotationError
- write test cases to test the validator and pre processing of annotation objects
- move validation call of annotation to api.views.AnnotationListView.post
