### PR TITLE
Add query parameter "return" to customize the return location in the annotator navigation

### DIFF
--- a/neonion/static/js/angular/controllers/annotator/annotator-nav.js
+++ b/neonion/static/js/angular/controllers/annotator/annotator-nav.js
@@ -1,8 +1,8 @@
 /**
  * AnnotatorMenu controller
  */
-neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$cookies', 'cookieKeys', 'AnnotatorService',
-    function ($scope, $window, $cookies, cookieKeys, AnnotatorService) {
+neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$location', '$cookies', 'cookieKeys', 'AnnotatorService',
+    function ($scope, $window, $location, $cookies, cookieKeys, AnnotatorService) {
         "use strict";
 
         $scope.annotatorService = AnnotatorService;
@@ -21,11 +21,12 @@ neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$cookies', 'co
                 value: Annotator.Plugin.Neonion.prototype.annotationModes.conceptTagging
             }
         };
+
         $scope.shortCutModifier = {
             default: {
                 modifierText: "Ctrl+Alt+"
             }
-        }
+        };
 
         $scope.handleKeyDown = function (event) {
             if (event.ctrlKey && event.altKey) {
@@ -37,7 +38,19 @@ neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$cookies', 'co
                     }
                 }
             }
-        }
+        };
+
+        /**
+         * Handle home click.
+         */
+        $scope.home = function() {
+            if ($location.search().return) {
+                window.location = $location.search().return;
+            }
+            else {
+                window.location = "/";
+            }
+        };
 
         /**
          * Scrolls the view port to the last annotation.
@@ -68,7 +81,7 @@ neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$cookies', 'co
             else {
                 return 1;
             }
-        }
+        };
 
         $scope.setAnnotationMode = function (mode) {
             $cookies.put(cookieKeys.annotationMode, mode);

--- a/neonion/static/partials/annotator/annotator-navigation.html
+++ b/neonion/static/partials/annotator/annotator-navigation.html
@@ -1,7 +1,7 @@
 <nav class="nav-vertical">
     <ul ng-controller="AnnotatorMenuCtrl">
         <li>
-            <a id="nav-home" class="simptip-position-right" href="/" data-tooltip="Home">
+            <a id="nav-home" class="simptip-position-right" ng-click="home()" data-tooltip="Home">
                 <span class="fa fa-home fa-fw"></span>
             </a>
         </li>


### PR DESCRIPTION
Necessary to return to GMPG tool after annotating the document
