### PR TITLE
Upgrade to elasticsearch version 6

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ For neonion you need Python with Django installed.
 In addition, a set of tools and services is needed:
 
 * [Python](https://www.python.org) (Python 2 >=2.7) with `pip` and `virtualenv`
-* [ElasticSearch](https://www.elastic.co) (<=2.x)
+* [ElasticSearch](https://www.elastic.co) (>=5.x)
 * **Optional** 
   * [Sesame](http://rdf4j.org) (>=2.7)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.7
 djangorestframework==3.2.3
 django-pipeline==1.5.1
 requests==2.4.3
+elasticsearch==6.0.0
 enum34==1.0.4
-pyelasticsearch==1.4
 SPARQLWrapper==1.6.4
 beautifulsoup4==4.3.2

--- a/store/views.py
+++ b/store/views.py
@@ -45,14 +45,12 @@ def get_filter_query(parameters):
 
     return {
         "query": {
-            "match_all": {}
-        },
-        'filter': {
-            'bool': {
-                'must': query_params
+          "bool": {
+            "must": {"match_all": {}},
+            "filter": query_params
             }
+          }
         }
-    }
 
 
 class AnnotationListView(APIView):
@@ -170,7 +168,7 @@ class AnnotationDetailView(APIView):
             try:
                 es.index(settings.ELASTICSEARCH_INDEX, ANNOTATION_TYPE, annotation,
                          id=annotation['id'], overwrite_existing=True)
-		log_annotation_edited(request) 
+		log_annotation_edited(request)
             except:
                 return HttpResponse(status=500)
             else:


### PR DESCRIPTION
Upgrading to elasticsearch >= 5 necessitates changes to queries. Making use of elasticsearch >= 6 tho requires switching libraries, as `pyelasticsearch` does not seem to support explicit specification of `Content-Type` field in http header, which we need to do in order to comply with strict content type checking in elasticsearch version 6.