### PR TITLE
Update annotation index mapping for elasticsearch 6.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Setup neonion and startup the server:
 ```
 source pyenv/bin/activate
 cd neonion
-curl -XPUT 'http://127.0.0.1:9200/neonion/' -d @mapping.json
+curl -XPUT -H'Content-Type: application/json' 'http://127.0.0.1:9200/neonion/' -d @mapping.json
 python manage.py migrate
 python manage.py loaddata fixtures/*
 python manage.py runserver

--- a/mapping.json
+++ b/mapping.json
@@ -2,33 +2,33 @@
   "mappings": {
     "annotation": {
       "properties": {
-        "id": {"type": "string", "index": "no"},
+        "id": {"type": "text", "index": false},
         "created": {"type": "date"},
         "updated": {"type": "date"},
-        "quote": {"type": "string", "analyzer": "standard"},
-        "text": {"type": "string", "analyzer": "standard"},
-        "uri": {"type": "string", "index": "not_analyzed"},
+        "quote": {"type": "text", "analyzer": "standard"},
+        "text": {"type": "text", "analyzer": "standard"},
+        "uri": {"type": "keyword"},
         "oa": {
           "properties": {
-            "@id": {"type": "string", "index": "no"},
-            "@type": {"type": "string", "index": "not_analyzed"},
-            "@context": {"type": "string", "index": "no"},
+            "@id": {"type": "text", "index": false},
+            "@type": {"type": "keyword"},
+            "@context": {"type": "text", "index": false},
             "annotatedAt": {"type": "date"},
-            "motivatedBy": {"type": "string", "index": "not_analyzed"},
+            "motivatedBy": {"type": "keyword"},
             "hasBody": {
               "properties": {
-                "@id": {"type": "string", "index": "no"},
-                "@type": {"type": "string", "index": "not_analyzed"}
+                "@id": {"type": "text", "index": false},
+                "@type": {"type": "keyword"}
               }
             },
             "hasTarget": {
               "properties": {
-                "@id": {"type": "string", "index": "no"},
-                "@type": {"type": "string", "index": "not_analyzed"},
+                "@id": {"type": "text", "index": false},
+                "@type": {"type": "keyword"},
                 "hasSource": {
                   "properties": {
-                    "@id": {"type": "string", "index": "not_analyzed"},
-                    "@type": {"type": "string", "index": "not_analyzed"}
+                    "@id": {"type": "keyword"},
+                    "@type": {"type": "keyword"}
                   }
                 }
               }
@@ -42,8 +42,8 @@
                 "pageIndex": {"type": "integer"},
                 "surrounding": {
                   "properties": {
-                    "left": {"type": "string", "index": "no"},
-                    "right": {"type": "string", "index": "no"}
+                    "left": {"type": "text", "index": false},
+                    "right": {"type": "text", "index": false}
                   }
                 },
                 "normalizedHighlights": {
@@ -60,18 +60,18 @@
         },
         "ranges": {
             "properties": {
-                "start": {"type": "string", "index": "no"},
-                "end": {"type": "string", "index": "no"},
-                "startOffset": {"type": "integer", "index": "no"},
-                "endOffset": {"type": "integer", "index": "no"}
+                "start": {"type": "text", "index": false},
+                "end": {"type": "text", "index": false},
+                "startOffset": {"type": "integer", "index": false},
+                "endOffset": {"type": "integer", "index": false}
             }
         },
         "permissions": {
             "properties": {
-                "read": {"type": "string", "index": "not_analyzed"},
-                "update": {"type": "string", "index": "not_analyzed"},
-                "delete": {"type": "string", "index": "not_analyzed"},
-                "admin": {"type": "string", "index": "not_analyzed"}
+                "read": {"type": "keyword"},
+                "update": {"type": "keyword"},
+                "delete": {"type": "keyword"},
+                "admin": {"type": "keyword"}
             }
         }
       }

--- a/store/views.py
+++ b/store/views.py
@@ -200,7 +200,7 @@ class SearchView(generics.GenericAPIView):
             query = get_filter_query(params)
             response = es.search(body=query, index=settings.ELASTICSEARCH_INDEX,
                                  doc_type=ANNOTATION_TYPE, from_=offset, size=size)
-        except exceptions.ElasticHttpNotFoundError:
+        except exceptions.TransportError:
             return JsonResponse(empty_result())
         except:
             return HttpResponse(status=500)
@@ -223,7 +223,7 @@ def search(request, format=None):
         query = get_filter_query(params)
         response = es.search(body=query, index=settings.ELASTICSEARCH_INDEX,
                              doc_type=ANNOTATION_TYPE, from_=offset, size=size)
-    except exceptions.ElasticHttpNotFoundError:
+    except exceptions.TransportError:
         return JsonResponse(empty_result())
     except:
         return HttpResponse(status=500)


### PR DESCRIPTION
Elasticsearch index mapping file `mapping.json` no longer can be used to create and configure `neonion` index for annotation objects due to [breaking changes in ES 5](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_mapping_changes.html). Some type names and field types have changed [[1]](https://stackoverflow.com/questions/47452770/no-handler-for-type-string-declared-on-field-name/47454366#47454366) [[2]](https://github.com/elastic/elasticsearch-rails/issues/761#issuecomment-353662525)

Furthermore, creation of `neonion` index via HTTP with `curl` now must be invoked with explicit specification of `Content-Type` header field as demanded by ES 6 and already described in 56dbb43 (merged with #94). So README has to be changed as well.
    

