### PR TITLE
Wikidata live entity search

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,7 +15,7 @@ class FileSerializer(serializers.ModelSerializer):
 class DocumentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Document
-        fields = ('id', 'uri', 'title', 'created', 'updated', 'workinggroup_set')
+        fields = ('id', 'uri', 'title', 'created', 'updated', 'workinggroup_set', 'concept_set')
 
 
 # Serializers for full document representation representation.
@@ -24,7 +24,7 @@ class DocumentDetailedSerializer(DocumentSerializer):
 
     class Meta:
         model = Document
-        fields = ('id', 'uri', 'title', 'created', 'updated', 'attached_file', 'workinggroup_set')
+        fields = ('id', 'uri', 'title', 'created', 'updated', 'attached_file', 'workinggroup_set', 'concept_set') #'annotation_set_id'
 
 
 # Serializer for user representation.

--- a/documents/models.py
+++ b/documents/models.py
@@ -63,6 +63,9 @@ class DocumentManager(models.Manager):
 
 
 class Document(ResourceMixin, models.Model):
+
+    concept_set = models.ForeignKey('annotationsets.ConceptSet', on_delete=models.SET_DEFAULT, default='default')
+
     title = models.CharField('name', max_length=500)
     attached_file = models.OneToOneField(File, null=True)
     creator = models.CharField('creator', max_length=500, default='', null=True)

--- a/documents/views.py
+++ b/documents/views.py
@@ -16,7 +16,7 @@ from logging.signals import log_document_metadata_request_error
 def upload_file(request):
     document_properties = {}
     document_fields = ["title", "creator", "type", "contributor", "coverage", "description", "format", "identifier",
-                       "language", "publisher", "relation", "rights", "source", "subject"]
+                       "language", "publisher", "relation", "rights", "source", "subject", "concept_set"]
 
     for m in document_fields:
         document_properties[m] = request.POST.get(m, None)  # fetches value or provides default if it does not exist

--- a/fixtures/accounts.json
+++ b/fixtures/accounts.json
@@ -39,7 +39,10 @@
       "is_superuser": true,
       "password": "pbkdf2_sha256$12000$TG8p0bASUBWu$0VvZ5qoawys5kyFogTxRDy4pn33Vv4V/Xot//X9MraU=",
       "email": "neonion-admin@fu-berlin.de",
-      "username": "neonion-admin@fu-berlin.de"
+      "username": "neonion-admin@fu-berlin.de",
+			"owned_documents": [
+				"ac93538cc28a11e4b948c42c0303b893"
+			]
     },
     "model": "accounts.user",
     "pk": 2

--- a/neonion/static/js/angular/controllers/annotator/annotator-nav.js
+++ b/neonion/static/js/angular/controllers/annotator/annotator-nav.js
@@ -110,6 +110,33 @@ neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$location', '$
             }
         };
 
+        $scope.return = function () {
+            $scope.$emit("returnEvent");
+        };
+
+        $scope.getConceptSet = function () {
+            var conceptSetId = $scope.document ? $scope.document.concept_set : 'default';
+
+            return ConceptSetService.getDeep({id: conceptSetId},
+                function (conceptSet) {
+                    $scope.conceptSet = conceptSet
+                }).$promise;
+        };
+
+        $scope.switchConceptSet = function(conceptSetId) {
+            console.log('change concept set to '+conceptSetId);
+            $scope.document.concept_set = conceptSetId;
+
+            ConceptSetService.getDeep({id: conceptSetId},
+                function (conceptSet) {
+                    $scope.conceptSet = conceptSet
+                }).$promise.then(function(data){
+                    AnnotatorService.annotator().plugins.neonion.conceptSet($scope.conceptSet.concepts);
+                    $scope.document.$update($scope.return);
+            });
+        }
+
+
         /**
          * Find the right method, call on correct element.
          */

--- a/neonion/static/js/angular/controllers/annotator/annotator-nav.js
+++ b/neonion/static/js/angular/controllers/annotator/annotator-nav.js
@@ -8,7 +8,7 @@ neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$location', '$
 
         $scope.systemSettings = systemSettings;
         $scope.annotatorService = AnnotatorService;
-        $scope.conceptSetService = ConceptSetService;
+
         $scope.mode = {
             commenting: {
                 shortCut: "A",
@@ -23,6 +23,9 @@ neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$location', '$
                 value: Annotator.Plugin.neonion.prototype.annotationModes.conceptTagging
             }
         };
+
+        $scope.conceptSets = ConceptSetService.query();
+
 
         $scope.shortCutModifier = {
             default: {

--- a/neonion/static/js/angular/controllers/annotator/annotator-nav.js
+++ b/neonion/static/js/angular/controllers/annotator/annotator-nav.js
@@ -2,12 +2,13 @@
  * AnnotatorMenu controller
  */
 neonionApp.controller('AnnotatorMenuCtrl', ['$scope', '$window', '$location', '$cookies',
-    'cookieKeys', 'systemSettings', 'AnnotatorService',
-    function ($scope, $window, $location, $cookies, cookieKeys, systemSettings, AnnotatorService) {
+    'cookieKeys', 'systemSettings', 'AnnotatorService', 'ConceptSetService',
+    function ($scope, $window, $location, $cookies, cookieKeys, systemSettings, AnnotatorService, ConceptSetService) {
         "use strict";
 
         $scope.systemSettings = systemSettings;
         $scope.annotatorService = AnnotatorService;
+        $scope.conceptSetService = ConceptSetService;
         $scope.mode = {
             commenting: {
                 shortCut: "A",

--- a/neonion/static/js/angular/controllers/annotator/annotator.js
+++ b/neonion/static/js/angular/controllers/annotator/annotator.js
@@ -33,7 +33,7 @@ neonionApp.controller('AnnotatorCtrl', ['$scope', '$cookies', '$location', '$sce
         $scope.getConceptSet = function () {
             var conceptSetId = $scope.group ? $scope.group.concept_set : 'default';
 
-            return ConceptSetService.getDeep({id: conceptSetId}, 
+            return ConceptSetService.resource.getDeep({id: conceptSetId},
                 function (conceptSet) {
                     $scope.conceptSet = conceptSet
                 }).$promise;                

--- a/neonion/static/js/angular/controllers/annotator/annotator.js
+++ b/neonion/static/js/angular/controllers/annotator/annotator.js
@@ -3,9 +3,9 @@
 /**
  * Annotator controller
  */
-neonionApp.controller('AnnotatorCtrl', ['$scope', '$cookies', '$location', '$sce', 'cookieKeys',
+neonionApp.controller('AnnotatorCtrl', ['$scope', '$rootScope', '$cookies', '$location', '$sce', 'cookieKeys',
     'UserService', 'AnnotatorService', 'DocumentService', 'GroupService', 'ConceptSetService',
-    function ($scope, $cookies, $location, $sce, cookieKeys, UserService, AnnotatorService, 
+    function ($scope, $rootScope, $cookies, $location, $sce, cookieKeys, UserService, AnnotatorService,
             DocumentService, GroupService, ConceptSetService) {
         "use strict";
 
@@ -13,6 +13,7 @@ neonionApp.controller('AnnotatorCtrl', ['$scope', '$cookies', '$location', '$sce
             if ($scope.hasOwnProperty("documentId")) {
                 return DocumentService.get({id: $scope.documentId}, function (document) {
                     $scope.document = document;
+                    $rootScope.document = document;
                 }).$promise;
             }
             return Promise.resolve(true);
@@ -31,7 +32,7 @@ neonionApp.controller('AnnotatorCtrl', ['$scope', '$cookies', '$location', '$sce
         };
 
         $scope.getConceptSet = function () {
-            var conceptSetId = $scope.group ? $scope.group.concept_set : 'default';
+            var conceptSetId = $scope.document ? $scope.document.concept_set : 'default';
 
             return ConceptSetService.getDeep({id: conceptSetId},
                 function (conceptSet) {
@@ -59,6 +60,7 @@ neonionApp.controller('AnnotatorCtrl', ['$scope', '$cookies', '$location', '$sce
                 };
             }).$promise
                 .then(function () {
+                    $rootScope.documentId = $scope.documentId;
                     angular.element("#document-body").annotator()
                         // add store plugin
                         .annotator('addPlugin', 'Store', {

--- a/neonion/static/js/angular/controllers/annotator/annotator.js
+++ b/neonion/static/js/angular/controllers/annotator/annotator.js
@@ -33,7 +33,7 @@ neonionApp.controller('AnnotatorCtrl', ['$scope', '$cookies', '$location', '$sce
         $scope.getConceptSet = function () {
             var conceptSetId = $scope.group ? $scope.group.concept_set : 'default';
 
-            return ConceptSetService.resource.getDeep({id: conceptSetId},
+            return ConceptSetService.getDeep({id: conceptSetId},
                 function (conceptSet) {
                     $scope.conceptSet = conceptSet
                 }).$promise;                

--- a/neonion/static/js/angular/controllers/vocabulary/conceptset-list.js
+++ b/neonion/static/js/angular/controllers/vocabulary/conceptset-list.js
@@ -14,7 +14,7 @@ neonionApp.controller('ConceptSetListCtrl', ['$scope', '$sce', 'CommonService', 
             };
 
             $scope.queryConceptSets = function () {
-                return ConceptSetService.resource.query(function (data) {
+                return ConceptSetService.query(function (data) {
                     $scope.resources = data;
                 }).$promise;
             };

--- a/neonion/static/js/angular/controllers/vocabulary/conceptset-list.js
+++ b/neonion/static/js/angular/controllers/vocabulary/conceptset-list.js
@@ -14,7 +14,7 @@ neonionApp.controller('ConceptSetListCtrl', ['$scope', '$sce', 'CommonService', 
             };
 
             $scope.queryConceptSets = function () {
-                return ConceptSetService.query(function (data) {
+                return ConceptSetService.resource.query(function (data) {
                     $scope.resources = data;
                 }).$promise;
             };

--- a/neonion/static/js/angular/services/conceptset.js
+++ b/neonion/static/js/angular/services/conceptset.js
@@ -1,6 +1,9 @@
 neonionApp.factory('ConceptSetService', ['$resource',
         function ($resource) {
-            return $resource('/api/conceptsets/:id',
+
+            factory = {};
+
+            factory.resource = $resource('/api/conceptsets/:id',
                 {id: '@id'},
                 {
                     'save': {method: 'POST', url: '/api/conceptsets/'},
@@ -8,5 +11,13 @@ neonionApp.factory('ConceptSetService', ['$resource',
                     'getDeep': {method: 'GET', isArray: false, params: {deep: true}}
                 }
             );
-        }]
+
+            factory.conceptSets = factory.resource.query(function(data){
+               return data;
+            });
+
+
+            return factory;
+        }
+    ]
 );

--- a/neonion/static/js/angular/services/conceptset.js
+++ b/neonion/static/js/angular/services/conceptset.js
@@ -1,9 +1,6 @@
 neonionApp.factory('ConceptSetService', ['$resource',
         function ($resource) {
-
-            factory = {};
-
-            factory.resource = $resource('/api/conceptsets/:id',
+            return $resource('/api/conceptsets/:id',
                 {id: '@id'},
                 {
                     'save': {method: 'POST', url: '/api/conceptsets/'},
@@ -11,13 +8,5 @@ neonionApp.factory('ConceptSetService', ['$resource',
                     'getDeep': {method: 'GET', isArray: false, params: {deep: true}}
                 }
             );
-
-            factory.conceptSets = factory.resource.query(function(data){
-               return data;
-            });
-
-
-            return factory;
-        }
-    ]
+        }]
 );

--- a/neonion/static/js/angular/services/conceptset.js
+++ b/neonion/static/js/angular/services/conceptset.js
@@ -9,4 +9,5 @@ neonionApp.factory('ConceptSetService', ['$resource',
                 }
             );
         }]
+
 );

--- a/neonion/static/js/angular/services/document.js
+++ b/neonion/static/js/angular/services/document.js
@@ -15,7 +15,9 @@ neonionApp.factory('DocumentService', ['$resource',
                         });
                         return names;
                     }
-                }
+                },
+                'save': {method: 'POST', url:'/api/documents/'},
+                'update': {method: 'PUT'}
             });
     }]
 );

--- a/neonion/static/js/annotator/annotator.neonion.extensions.js
+++ b/neonion/static/js/annotator/annotator.neonion.extensions.js
@@ -339,6 +339,7 @@
                 // replace list with spinner while loading
                 list.html(factory.templates.spinner);
 
+                // XXX ufff selection of first linked concept is hard-coded
                 var indexName = factory.getIndexName(concept.linked_concepts[0].endpoint);
                 // lookup resource by search term and provided index
                 this.search(concept.id, searchTerm, indexName)
@@ -386,12 +387,15 @@
             }
         };
 
+
         factory.search = function (type, searchText, index) {
             var url = scope.options.lookup.prefix + scope.options.lookup.urls.search +
                 "/" + encodeURI(index) + "/" + encodeURI(type) + "/" + encodeURI(searchText);
             return $.getJSON(url);
         };
 
+
+        // XXX mystisch
         factory.updateScoreAccordingOccurrence = function (items) {
             var annotations = scope.getAnnotations();
             var occurrence = {};

--- a/neonion/static/js/annotator/annotator.neonion.js
+++ b/neonion/static/js/annotator/annotator.neonion.js
@@ -857,7 +857,11 @@
 
         formatter: {
             'default': function (value) {
-                return "<span>" + value.label + "</span>";
+                var repr = "<span>" + value.label + "</span>";
+                if (value.descr) {
+                    repr += "<br/><span>" + value.descr + "</span>";
+                }
+                return repr;
             }
         }
 

--- a/neonion/static/js/annotator/annotator.neonion.js
+++ b/neonion/static/js/annotator/annotator.neonion.js
@@ -198,7 +198,8 @@
                 'contextInformation',
                 'visualizeRelationship',
                 'viewerSummarizeStatements',
-                'pointAndLightRelations'
+                'pointAndLightRelations',
+                'wikidataLiveEntitySearch'
             ],
             lookup: {
                 prefix: "/api/es/",

--- a/neonion/static/partials/annotator/annotator-navigation.html
+++ b/neonion/static/partials/annotator/annotator-navigation.html
@@ -59,6 +59,8 @@
             </ul>
         </li>
 
+
+
         <li class="dropdown">
             <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                 <i class="fa fa-weixin" aria-hidden="true"></i>
@@ -66,10 +68,10 @@
             </a>
             <ul class="dropdown-menu dropdown-menu-side">
                 <li class="dropdown-header">Select Concept Set</li>
-                <li class="dropdown-item" ng-repeat="conceptSet in conceptSets">
+                <li class="dropdown-item" ng-repeat="conceptSet in conceptSets" ng-click="switchConceptSet(conceptSet.id)">
                     <a>
-                        <i class="fa fa-fw" ng-class="{'fa-eye': conceptSet.selectConceptSet}"></i>
-                        <span>{{ conceptSet.label}}</span>
+                        <i class="fa fa-check fa-fw" ng-class="{invisible: document.concept_set !== conceptSet.id || !document.concept_set}"/>
+                        <span>{{ conceptSet.label}}</span><small>{{ conceptSet.comment }}</small>
                     </a>
                 </li>
             </ul>

--- a/neonion/static/partials/annotator/annotator-navigation.html
+++ b/neonion/static/partials/annotator/annotator-navigation.html
@@ -66,7 +66,7 @@
             </a>
             <ul class="dropdown-menu dropdown-menu-side">
                 <li class="dropdown-header">Select Concept Set</li>
-                <li class="dropdown-item" ng-repeat="conceptSet in conceptSetService.conceptSets">
+                <li class="dropdown-item" ng-repeat="conceptSet in conceptSets">
                     <a>
                         <i class="fa fa-fw" ng-class="{'fa-eye': conceptSet.selectConceptSet}"></i>
                         <span>{{ conceptSet.label}}</span>

--- a/neonion/static/partials/annotator/annotator-navigation.html
+++ b/neonion/static/partials/annotator/annotator-navigation.html
@@ -59,6 +59,22 @@
             </ul>
         </li>
 
+        <li class="dropdown">
+            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                <i class="fa fa-weixin" aria-hidden="true"></i>
+                <i class="fa fa-caret-right small"></i>
+            </a>
+            <ul class="dropdown-menu dropdown-menu-side">
+                <li class="dropdown-header">Select Concept Set</li>
+                <li class="dropdown-item" ng-repeat="conceptSet in conceptSetService.conceptSets">
+                    <a>
+                        <i class="fa fa-fw" ng-class="{'fa-eye': conceptSet.selectConceptSet}"></i>
+                        <span>{{ conceptSet.label}}</span>
+                    </a>
+                </li>
+            </ul>
+        </li>
+
         <li>
             <a id="nav-anotate" class="simptip-position-right" data-tooltip="Last annotation"
                ng-click="scrollToLastAnnotation()">

--- a/neonion/urls.py
+++ b/neonion/urls.py
@@ -26,6 +26,9 @@ urlpatterns = [
     url(r'^documents/', include('documents.urls')),
     url(r'^endpoint/', include('endpoint.urls')),
 
+    # wikidata application
+    url(r'^wikidata/', include('wikidata.urls')),
+
 
     # Django rest
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))

--- a/settings/default.py
+++ b/settings/default.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = (
     'accounts',
     'endpoint',
     'annotationsets',
+    'wikidata',
 )
 
 AUTH_USER_MODEL = 'accounts.User'
@@ -199,7 +200,7 @@ ENDPOINT_UPDATE = 'http://localhost:8080/openrdf-sesame/repositories/neonion/sta
 NER_SERVICE_ENABLED = False
 NER_SERVICE_URL = 'http://localhost:6000'
 
-#LOGGING_CONFIG 
+#LOGGING_CONFIG
 KIBANA_URL = 'http://127.0.0.1:5601'
 USER_LOGGING_ENABLED = False
 LOGGING = {

--- a/wikidata/models.py
+++ b/wikidata/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/wikidata/static/js/annotator/annotator.neonion.wikidata.js
+++ b/wikidata/static/js/annotator/annotator.neonion.wikidata.js
@@ -1,0 +1,35 @@
+(function () {
+  "use strict";
+
+
+  Annotator.Plugin.neonion.prototype.widgets['wikidataLiveEntitySearch'] = function (scope, options) {
+    var factory = {};
+
+    factory.load = function () {
+
+      // overwrite local endpoint called for entity search
+      scope.options.lookup = {
+        prefix: '/wikidata',
+        urls: {
+          search: "/itemsearch"
+        }
+      };
+
+      scope.annotator.subscribe('annotationEditorShown', function (editor, annotation) {
+
+        console.log(annotation);
+        console.log(scope.options);
+
+      });
+
+      scope.annotator.subscribe('annotationEditorHidden', function () {
+
+
+      });
+
+    };
+
+    return factory;
+
+  }
+})();

--- a/wikidata/urls.py
+++ b/wikidata/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+
+
+urlpatterns = [
+        url(r'^itemsearch/(?P<index>.*)/(?P<concept_id>.*)/(?P<term>.*)$', 'wikidata.views.search_typed_items'),
+        ]

--- a/wikidata/views.py
+++ b/wikidata/views.py
@@ -1,3 +1,4 @@
+import re
 import json
 import requests
 from urllib import urlencode
@@ -11,64 +12,140 @@ from annotationsets.models import Concept, LinkedConcept
 
 import wiki
 
+# action, search, limit
+# TODO determine lang parameter based on language of document
+wbapi_url_template = "https://www.wikidata.org/w/api.php?format=json&language=en&uselang=en&{}"
 
-query_temp = "https://www.wikidata.org/w/api.php?action=wbsearchentities&language=en&format=json&uselang=en&{}"
+# insert 2 lists of items: instances and types to match against
+types_query_template = 'VALUES ?item {{{}}} . VALUES ?type {{{}}} . ?item wdt:P31/wdt:P279* ?type.'
+
+# insert filtered list of items
+birth_death_query_template = 'VALUES ?item {{{}}} . OPTIONAL {{ ?item wdt:P569 ?birth }} . OPTIONAL {{ ?item wdt:P570 ?death }}'
+
+# regular expression for parsing wikidata xs:dateTime literals
+rx_dateTime = re.compile('^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-2][0-9]:[0-5][0-9]:[0-5][0-9]).*$')
+
+
+#temporal_properties = {
+#        "birth": "P569",
+#        "death": "P570"
+#        }
+
+
+# render QId list to string with wd: prefix for every ID and space as delimiter
+# (can be used for sparql expression ' VALUES ?item {...} . '
+wd_item_id_list = lambda qids: ' '.join(['wd:' + qid for qid in qids])
+
+def wbsearchentities(terms, limit=50):
+    """Queries Wikidata's Wikibase API endpoint with action wbsearchentities"""
+    res = []
+    if terms and len(terms) > 0:
+        url = wbapi_url_template.format(urlencode({
+            "action": "wbsearchentities",
+            "search": terms,
+            "limit": limit
+            }))
+        response = requests.get(url)
+        if response.status_code == 200:
+            for i, result in enumerate(response.json().get('search', [])):
+                res.append(result)
+                result['rank'] = i
+    return res
+
+def validate_item_types(results, concept):
+    """Takes an id:search_result dict and flags all items that match a linked concept of the passed neonion concept."""
+    # extract Q-ids from URLs of external types linked to concept
+    concept_linked_types_qids = [lc.linked_type.split('/')[-1] for lc in concept.linked_concepts.all()]
+    # fill in item and type lists in SPARQL query
+    query = types_query_template.format(
+            wd_item_id_list(results.keys()),
+            wd_item_id_list(concept_linked_types_qids)
+            )
+    # query WDQS endpoint, retrieve pywikidata ItemPage objects
+    items = wiki.query(query)
+    # in the search result dictionary, flag all items that are amongst results of previous SPARQL query
+    for item in items:
+        results[item.id]['valid'] = True
+    # return
+    return results
+
+
+def add_temporal_data(results):
+    """Try to retrieve timespan information like dates of birth and death."""
+    # insert item IDs into SPARQL query template (only items of valid type for classifying concept)
+    query = birth_death_query_template.format(
+            wd_item_id_list(
+                [k for k,v in results.items() if v.get('valid')]
+                )
+            )
+    # query WDQS endpoint and retrieve JSON
+    data = wiki.sparql(query)
+    # TODO problem is that in order to do this properly, we would need to resolve predicate qualifiers because otherwise we
+    # TODO can't tell whether a date is of the Gregorian or Julian calendar, nor what is its granularity/precision.
+    # TODO this means we would specify the temporal properties not with wdt: but with p: prefix (which will return a statement url rather than a dateTime literal as value)
+    # TODO and somehow address the statement's properties in the query. that's ridiculously complicated so we don't do it for now.
+    # process response
+    for row in data:
+        # get corresponding entry in results dictionary (key: wd url hindmost segment of path)
+        item = results.get(row.get('item', {}).get('value', '').split('/')[-1])
+        # parse values for specified properties
+        for prop in ['birth', 'death']:
+            predicate = row.get(prop, {})
+            if predicate.get('datatype') == 'http://www.w3.org/2001/XMLSchema#dateTime' and predicate.get('type') == 'literal':
+                values = rx_dateTime.findall(predicate.get('value', ''))
+                if len(values) > 0:
+                    # if value available, write into dictionary
+                    item[prop] = values[0][0]
+    return results
+
+
+
+# key mapping from wikidata to neonion (annotator controller)
+mappings = {
+        "description" : "descr",
+        "concepturi": "uri",
+        "repository": None,
+        "title": None
+        }
 
 def map_result(item):
-    if type(item) == dict:
-        return {
-            "descr": item.get('description',''),
-            "label": item.get('label',''),
-            "id": item.get('id', ''),
-            "uri": item.get('concepturi', ''),
-            "aliases": item.get('aliases', []),
-            "valid": item.get('valid', False),
-            "rank": item.get('rank', -1)
-        }
-    elif type(item) == wiki._wiki.page.ItemPage:
-        return {
-            "descr": item.__dict__.get('descriptions',{}).get('en', ''),
-            "label": item.__dict__.get('labels',{}).get('en', ''),
-            "id": item.id,
-            "uri": item.full_url(),
-            "aliases": [a for a in item.__dict__.get('aliases', {}).values()],
-            "valid": True
-            }
+    for wd_key, key in mappings.items():
+        if key:
+            item[key] = item.get(wd_key)
+        if wd_key in item:
+            del item[wd_key]
+    return item
 
 
-def concept_linked_types_qids(concept):
-    return [lc.linked_type.split('/')[-1] for lc in concept.linked_concepts.all()]
 
+###########################################################################################################
+##                                              VIEWS                                                    ##
+###########################################################################################################
 
 def search_typed_items(request, index, concept_id, term):
 
-    url = query_temp.format(urlencode({"search":term}))
-    response = requests.get(url)
+    item_list = []
 
-    print(concept_id)
-    print(response.json())
-
-    results = []
-    for i, result in enumerate(response.json()['search']):
-        results.append(result)
-        result['rank'] = i
+    # go search for entities with matching labels/aliases
+    results = wbsearchentities(term)
+    # convert result list to dictionary, use ids as keys
     results = {result['id']:result for result in results}
 
+    # retrieve neonion concept used for classification of selected terms
     concept = Concept.objects.get(id=concept_id)
-    print(concept)
-    print(concept.id)
-    query = 'VALUES ?item {{{}}} . VALUES ?type {{{}}} . ?item wdt:P31/wdt:P279* ?type.'.format(
-            ' '.join(['wd:'+qid for qid in results.keys()]),
-            ' '.join(['wd:'+qid for qid in concept_linked_types_qids(concept)]))
+    results = validate_item_types(results, concept)
 
-    items = wiki.query(query)
-    for item in items:
-        print(item.full_url())
-        results[item.id]['valid'] = True
+    # try to enhance search results with life span information for persons
+    # TODO add temporal data extraction and formatting for other concepts as well
+    if concept_id == 'person':
+        results = add_temporal_data(results)
 
-    if response.status_code == 200:
-        item_list = filter(lambda r:r.get('valid'), map(map_result, sorted(results.values(), key=lambda r:r.get('rank',-1))))
+    # return only matching items of valid type, mapped into schema expected by annotator controller and sorted by original rank
+    item_list = filter(lambda r:r.get('valid'),
+            map(map_result,
+                sorted(results.values(),
+                    key=lambda r:r.get('rank',-1))))
+
     return JsonResponse(item_list, safe=False)
 
 
-# Create your views here.

--- a/wikidata/views.py
+++ b/wikidata/views.py
@@ -13,8 +13,7 @@ from annotationsets.models import Concept, LinkedConcept
 import wiki
 
 # action, search, limit
-# TODO determine lang parameter based on language of document
-wbapi_url_template = "https://www.wikidata.org/w/api.php?format=json&language=en&uselang=en&{}"
+wbapi_url_template = "https://www.wikidata.org/w/api.php?format=json&{}"
 
 # insert 2 lists of items: instances and types to match against
 types_query_template = 'VALUES ?item {{{}}} . VALUES ?type {{{}}} . ?item wdt:P31/wdt:P279* ?type.'
@@ -40,14 +39,17 @@ wd_opt_props = ' . '.join(
         ['OPTIONAL {{ ?item wdt:{} ?{} }}'.format(v, k)
             for k, v in temporal_properties.items()])
 
-def wbsearchentities(terms, limit=50):
+# TODO determine lang parameter based on language of document
+def wbsearchentities(terms, limit=50, lang='en'):
     """Queries Wikidata's Wikibase API endpoint with action wbsearchentities"""
     res = []
     if terms and len(terms) > 0:
         url = wbapi_url_template.format(urlencode({
             "action": "wbsearchentities",
             "search": terms,
-            "limit": limit
+            "limit": limit,
+            "language": lang,
+            "uselang": lang
             }))
         response = requests.get(url)
         if response.status_code == 200:

--- a/wikidata/views.py
+++ b/wikidata/views.py
@@ -1,0 +1,74 @@
+import json
+import requests
+from urllib import urlencode
+
+from django.shortcuts import render
+from django.http import JsonResponse
+from django.contrib.auth.decorators import login_required
+from django.views.decorators.http import require_GET
+
+from annotationsets.models import Concept, LinkedConcept
+
+import wiki
+
+
+query_temp = "https://www.wikidata.org/w/api.php?action=wbsearchentities&language=en&format=json&uselang=en&{}"
+
+def map_result(item):
+    if type(item) == dict:
+        return {
+            "descr": item.get('description',''),
+            "label": item.get('label',''),
+            "id": item.get('id', ''),
+            "uri": item.get('concepturi', ''),
+            "aliases": item.get('aliases', []),
+            "valid": item.get('valid', False),
+            "rank": item.get('rank', -1)
+        }
+    elif type(item) == wiki._wiki.page.ItemPage:
+        return {
+            "descr": item.__dict__.get('descriptions',{}).get('en', ''),
+            "label": item.__dict__.get('labels',{}).get('en', ''),
+            "id": item.id,
+            "uri": item.full_url(),
+            "aliases": [a for a in item.__dict__.get('aliases', {}).values()],
+            "valid": True
+            }
+
+
+def concept_linked_types_qids(concept):
+    return [lc.linked_type.split('/')[-1] for lc in concept.linked_concepts.all()]
+
+
+def search_typed_items(request, index, concept_id, term):
+
+    url = query_temp.format(urlencode({"search":term}))
+    response = requests.get(url)
+
+    print(concept_id)
+    print(response.json())
+
+    results = []
+    for i, result in enumerate(response.json()['search']):
+        results.append(result)
+        result['rank'] = i
+    results = {result['id']:result for result in results}
+
+    concept = Concept.objects.get(id=concept_id)
+    print(concept)
+    print(concept.id)
+    query = 'VALUES ?item {{{}}} . VALUES ?type {{{}}} . ?item wdt:P31/wdt:P279* ?type.'.format(
+            ' '.join(['wd:'+qid for qid in results.keys()]),
+            ' '.join(['wd:'+qid for qid in concept_linked_types_qids(concept)]))
+
+    items = wiki.query(query)
+    for item in items:
+        print(item.full_url())
+        results[item.id]['valid'] = True
+
+    if response.status_code == 200:
+        item_list = filter(lambda r:r.get('valid'), map(map_result, sorted(results.values(), key=lambda r:r.get('rank',-1))))
+    return JsonResponse(item_list, safe=False)
+
+
+# Create your views here.

--- a/wikidata/wiki.py
+++ b/wikidata/wiki.py
@@ -1,1 +1,87 @@
-/home/thor/uni/2016w/wd/wikidata/wiki.py
+#!/usr/bin/python
+
+import re as _re
+from datetime import datetime
+
+import pywikibot as _wiki
+print(_wiki.version.getversiondict())
+
+from pywikibot import pagegenerators as pg
+
+from SPARQLWrapper import SPARQLWrapper, JSON
+
+__all__ = ['repo', 'sparql', 'item', 'prop', 'label', 'extract_id', 'query']
+
+_sparqli = SPARQLWrapper('https://query.wikidata.org/bigdata/namespace/wdq/sparql')
+_sparqli.setReturnFormat(JSON)
+
+_site = _wiki.Site('wikidata', 'wikidata')
+repo = _site.data_repository()
+
+def create_item():
+  """ returns a newly created item page """
+  new_item = repo.editEntity(dict(), dict(), summary="created by script")
+  if new_item.get('success'):
+    qid = new_item.get('entity', {}).get('id')
+    return item(qid)
+
+def create_claim(pid, isReference=False):
+  """ Pass property identifier string (P...) """
+  return _wiki.Claim(repo, pid, isReference=isReference)
+
+def add_source_url(claim, source):
+  """ Adds given URL as a reference for specified claim and adds current date as reference as well. """
+  source_claim = create_claim('P248' if type(source) == _wiki.page.ItemPage else 'P854', isReference=True)
+  source_claim.setTarget(source)
+  now = datetime.now()
+  source_date = _wiki.WbTime(year=now.year, month=now.month, day=now.day)
+  date_claim = create_claim('P813', isReference=True)
+  date_claim.setTarget(source_date)
+  claim.addSources([source_claim, date_claim], bot=True)
+
+def create_date(date):
+  """ give date in format: 'YYYY-MM-DD' """
+  fields = date.split('-')
+  if len(fields) == 3:
+    kwargs = {key:int(fields[i]) for i,key in enumerate(['year','month','day'])}
+    return _wiki.WbTime(**kwargs)
+  return None
+
+def create_monolingualtext(text, lang):
+  """ returns a `WbMonolingualText` object with specified text and language
+  @param lang language code (en, de, ...)"""
+  return _wiki.WbMonolingualText(text, lang)
+
+def extract_id(url):
+  """ Extracts item or property ID from any string."""
+  return _re.findall("[PpQq][1-9][0-9]*", url)[0]
+
+def item(id):
+  if not id.lower().startswith('q'):
+    id = extract_id(id)
+  return _wiki.ItemPage(repo, id)
+
+
+def prop(id):
+  if not id.lower().startswith('p'):
+    id = extract_id(id)
+  return _wiki.PropertyPage(repo, id)
+
+
+def label(entity):
+  labels = entity.get().get('labels', {})
+  if 'en' in labels:
+    return labels.get('en')
+  else:
+    for v in labels.values():
+      return v
+
+def sparql(query, limit=500):
+  _sparqli.setQuery('select * where {{{}}} limit {}'.format(query, limit))
+  results = _sparqli.query().convert()
+  return results.get('results', {}).get('bindings', [])
+
+
+def query(query):
+    gen = pg.WikidataSPARQLPageGenerator('select ?item where {{{}}}'.format(query))
+    return [q for q in gen]

--- a/wikidata/wiki.py
+++ b/wikidata/wiki.py
@@ -1,0 +1,1 @@
+/home/thor/uni/2016w/wd/wikidata/wiki.py


### PR DESCRIPTION
Instead of querying local elasticsearch endpoint that might provide some wikidata dump, call online wikidata APIs directly during semantic classification. According to linked types of the concept used for classification of a text selection, appropriate entities are retrieved from wikidata. 
![screenshot from 2018-01-22 12-46-39](https://user-images.githubusercontent.com/1922142/35219880-987d5cee-ff74-11e7-8189-a1b5f324f09a.png)
